### PR TITLE
Fix config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ To get started with `gimme_readme`, follow these steps:
    npm i -g gimme_readme
    ```
 
-3. Generate a configuration file by running:
+   NOTE: MAC/LINUX users may need to run `sudo npm i -g gimme_readme`
+
+3. Generate a configuration file by running in _any_ folder you'd like:
 
    ```sh
    gr-ai -c

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gimme_readme",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gimme_readme",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@google/generative-ai": "^0.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,7 @@
         "commander": "^12.1.0",
         "dotenv": "^16.4.5",
         "groq-sdk": "^0.7.0",
-        "ora": "^8.1.0",
-        "pkg-dir": "^8.0.0"
+        "ora": "^8.1.0"
       },
       "bin": {
         "gr-ai": "src/_gr.js"
@@ -2657,17 +2656,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/find-up-simple": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.0.tgz",
-      "integrity": "sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -4706,20 +4694,6 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/pkg-dir": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-8.0.0.tgz",
-      "integrity": "sha512-4peoBq4Wks0riS0z8741NVv+/8IiTvqnZAr8QGgtdifrtpdXbNw/FxRS1l6NFqm4EMzuS0EDqNNx4XGaz8cuyQ==",
-      "dependencies": {
-        "find-up-simple": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/prelude-ls": {
@@ -7596,11 +7570,6 @@
         "path-exists": "^4.0.0"
       }
     },
-    "find-up-simple": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.0.tgz",
-      "integrity": "sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw=="
-    },
     "flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -9082,14 +9051,6 @@
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
       "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
       "dev": true
-    },
-    "pkg-dir": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-8.0.0.tgz",
-      "integrity": "sha512-4peoBq4Wks0riS0z8741NVv+/8IiTvqnZAr8QGgtdifrtpdXbNw/FxRS1l6NFqm4EMzuS0EDqNNx4XGaz8cuyQ==",
-      "requires": {
-        "find-up-simple": "^1.0.0"
-      }
     },
     "prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "commander": "^12.1.0",
     "dotenv": "^16.4.5",
     "groq-sdk": "^0.7.0",
-    "ora": "^8.1.0",
-    "pkg-dir": "^8.0.0"
+    "ora": "^8.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gimme_readme",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "gimme_readme is a command-line tool powered by AI that generates a comprehensive README.md file for your project. It analyzes multiple source code files at once, providing concise explanations of each file's purpose, functionality, and key components, all in a single, easy-to-read document. This makes your project more approachable and understandable for others.",
   "author": "Peter Wan",
   "license": "MIT",

--- a/src/_gr.js
+++ b/src/_gr.js
@@ -13,7 +13,6 @@ import os from 'os';
 import chalk from 'chalk';
 import ora from 'ora';
 import { fileURLToPath } from 'url';
-import { packageDirectory as pkgDir } from 'pkg-dir';
 
 // Define __dirname for ES Modules
 const __filename = fileURLToPath(import.meta.url);
@@ -37,21 +36,16 @@ async function main() {
   // Handle the config option
   if (options.config) {
     if (!fs.existsSync(configFilePath)) {
-      // Find the root directory of the project
-      const rootDir = await pkgDir(__dirname);
-      if (!rootDir) {
-        console.error('Unable to locate the root directory of the project.');
-        process.exit(1);
-      }
+      // Construct the path to env.sample within the gimme_readme project directory
+      const sampleFilePath = path.resolve(__dirname, '../env.sample'); // Adjust the path to point to gimme_readme/env.sample
 
-      // Construct the path to env.sample at the root of the project
-      const sampleFilePath = path.resolve(rootDir, 'env.sample');
       let sampleContent;
 
       try {
+        // Read the env.sample file from the gimme_readme directory
         sampleContent = fs.readFileSync(sampleFilePath, 'utf-8');
       } catch (err) {
-        console.error(`Could not find env.sample: ${err.message}`);
+        console.error(`Could not find env.sample in the project directory: ${err.message}`);
         process.exit(1);
       }
 
@@ -92,7 +86,6 @@ async function main() {
         prompt += content + '\n\n';
         validFiles.push(file);
       } catch (error) {
-        // Catch the error that's thrown if the file could not be read properly.
         console.error(error);
         process.exit(1);
       }


### PR DESCRIPTION
This should close #12. Now, users should be able to run `gr-ai -c` in any folder (provided they have ran `npm i -g gimme_readme` already).