### PR TITLE
Added -tkn / --token support for gimme_readme and also updated the test-suite to include support for the -tkn/--token functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,19 @@ See our [0.1 Release Demo](https://youtu.be/S6v-u9o_Xx8)!
 
 ## Table of Contents
 
-1. [Getting Started](#1-getting-started)
-2. [Usage](#2-usage)
-3. [Example Usage](#3-example-usage)
-4. [Supported Models by Providers](#4-supported-models-by-providers)
-5. [Contributing](#5-contributing)
-6. [Testing Locally](#6-testing-locally)
-7. [Author](#7-author)
+- [gimme\_readme](#gimme_readme)
+  - [Table of Contents](#table-of-contents)
+  - [1. Getting Started](#1-getting-started)
+  - [2. Usage](#2-usage)
+  - [3. Example Usage](#3-example-usage)
+    - [Display Help](#display-help)
+    - [Display Version Number](#display-version-number)
+    - [Generate a README for a Source File](#generate-a-readme-for-a-source-file)
+    - [Generate the number of tokens used during the API call](#generate-the-number-of-tokens-used-during-the-api-call)
+  - [4. Supported Models by Providers](#4-supported-models-by-providers)
+  - [5. Contributing](#5-contributing)
+  - [6. Testing Locally](#6-testing-locally)
+  - [7. Author](#7-author)
 
 ## 1. Getting Started
 
@@ -84,6 +90,13 @@ To generate a `README.md` file for one or more source files:
 
 ```sh
 gr-ai -f example.js anotherFile.py -o README.md -m gemini-1.5-flash
+```
+
+### Generate the number of tokens used during the API call
+
+```sh
+gr-ai -f example.js anotherFile.py -o README.md -m gemini-1.5-flash -tkn
+gr-ai -f example.js anotherFile.py -o README.md -m llama3-8b-8192 --token
 ```
 
 ## 4. Supported Models by Providers

--- a/src/_gr.js
+++ b/src/_gr.js
@@ -69,8 +69,9 @@ async function main() {
     // Let the user specify their own prompt, or use the prompt that we have engineered
     let prompt = options.prompt || process.env.CUSTOM_PROMPT || defaultPrompt;
     const model = options.model || process.env.MODEL || 'gemini-1.5-flash';
-    const outputFile = options.outputFile || process.env.OUTPUT_FILE || null;
+    const outputFile = options.outputFile || process.env.OUTPUT_FILE || null; // if no options are being specified, the option woudl be null, which means it will go out to terminal in the console
     const temperature = options.temperature || process.env.TEMPERATURE || 0.5;
+    const needToken = options.token || false;
 
     const validFiles = [];
 
@@ -103,7 +104,7 @@ async function main() {
     const spinner = ora(` Waiting for a response from the ${chalk.blue(model)} model...\n`).start();
 
     try {
-      await promptAI(prompt, model, temperature, outputFile);
+      await promptAI(prompt, model, temperature, outputFile, needToken);
       spinner.succeed(` Response received from ${chalk.blue(model)} model`);
     } catch (error) {
       spinner.fail(` Failed to receive response from ${chalk.red(model)} model`);
@@ -112,7 +113,7 @@ async function main() {
     }
   }
 
-  process.exit(0);
+  setTimeout(() => process.exit(0), 100);
 }
 
 main();

--- a/src/ai_config/geminiConfig.js
+++ b/src/ai_config/geminiConfig.js
@@ -20,7 +20,8 @@ export async function promptGemini(prompt, model, temperature = 0.5) {
     const generativeModel = genAI.getGenerativeModel({ model, temperature });
     const result = await generativeModel.generateContent(prompt);
     const responseText = result.response.text();
-    return responseText;
+    const usage = result.response.usageMetadata
+    return {responseText,usage};
   } catch (error) {
     throw new Error(`Error prompting Gemini: ${error.message}`);
   }

--- a/src/ai_config/geminiConfig.js
+++ b/src/ai_config/geminiConfig.js
@@ -20,8 +20,8 @@ export async function promptGemini(prompt, model, temperature = 0.5) {
     const generativeModel = genAI.getGenerativeModel({ model, temperature });
     const result = await generativeModel.generateContent(prompt);
     const responseText = result.response.text();
-    const usage = result.response.usageMetadata
-    return {responseText,usage};
+    const usage = result.response.usageMetadata;
+    return { responseText, usage };
   } catch (error) {
     throw new Error(`Error prompting Gemini: ${error.message}`);
   }

--- a/src/ai_config/groqConfig.js
+++ b/src/ai_config/groqConfig.js
@@ -37,13 +37,15 @@ export async function promptGroq(prompt, model, temperature = 0.5) {
     });
 
     const responseText = chatCompletion.choices[0]?.message?.content || '';
-    const tokenUsage = chatCompletion.usage || ''
-    return {responseText,usage:{
-      totalTokenCount:tokenUsage.total_tokens,
-      candidatesTokenCount:tokenUsage.completion_tokens,
-      promptTokenCount:tokenUsage.prompt_tokens
-
-    }}
+    const tokenUsage = chatCompletion.usage || '';
+    return {
+      responseText,
+      usage: {
+        totalTokenCount: tokenUsage.total_tokens,
+        candidatesTokenCount: tokenUsage.completion_tokens,
+        promptTokenCount: tokenUsage.prompt_tokens,
+      },
+    };
   } catch (error) {
     throw new Error(`Error prompting Groq: ${error.message}`);
   }

--- a/src/ai_config/groqConfig.js
+++ b/src/ai_config/groqConfig.js
@@ -37,7 +37,13 @@ export async function promptGroq(prompt, model, temperature = 0.5) {
     });
 
     const responseText = chatCompletion.choices[0]?.message?.content || '';
-    return responseText;
+    const tokenUsage = chatCompletion.usage || ''
+    return {responseText,usage:{
+      totalTokenCount:tokenUsage.total_tokens,
+      candidatesTokenCount:tokenUsage.completion_tokens,
+      promptTokenCount:tokenUsage.prompt_tokens
+
+    }}
   } catch (error) {
     throw new Error(`Error prompting Groq: ${error.message}`);
   }

--- a/src/commanderProgram.js
+++ b/src/commanderProgram.js
@@ -46,7 +46,7 @@ program.option(
   '-t, --temperature <number>',
   'specify how deterministic you want your AI to be (values should be between 0 to 1)'
 );
-program.option('-tkn,--token', 'specify the number of tokens used in the program');
+program.option('-tkn, --token', 'specify the number of tokens used in the program');
 
 // Exports the configured program
 export default program;

--- a/src/commanderProgram.js
+++ b/src/commanderProgram.js
@@ -46,6 +46,7 @@ program.option(
   '-t, --temperature <number>',
   'specify how deterministic you want your AI to be (values should be between 0 to 1)'
 );
+program.option('-tkn,--token', 'specify the number of tokens used in the program');
 
 // Exports the configured program
 export default program;

--- a/tests/unit/commanderProgram.test.js
+++ b/tests/unit/commanderProgram.test.js
@@ -46,6 +46,10 @@ describe('src/commanderProgram.js tests', () => {
         description:
           'specify how deterministic you want your AI to be (values should be between 0 to 1)',
       },
+      {
+        flags: '-tkn, --token',
+        description: 'specify the number of tokens used in the program',
+      },
     ];
 
     // Fetch all options defined in the program


### PR DESCRIPTION
This PR will resolve issue https://github.com/peterdanwan/gimme_readme/issues/21

This issue will now display the token used in the completion of the prompts when the -tkn or --token is used as can be seen below
<img width="1198" alt="Screenshot 2024-09-19 at 3 54 43 PM" src="https://github.com/user-attachments/assets/b6e623be-15d4-4c8e-8be9-813250edcaa8">

A description of the option has been added when the -h option is used and the README.md has also been updated.

<img width="1198" alt="Screenshot 2024-09-19 at 3 46 40 PM" src="https://github.com/user-attachments/assets/c716eaeb-c9ca-40a4-99c9-c0fe4b99978a">

The test suit has been updated to include the support for the -tkn / --token option

<img width="1198" alt="Screenshot 2024-09-19 at 7 48 09 PM" src="https://github.com/user-attachments/assets/ef14556a-db75-4d89-83db-2a1aa69d3fed">
