### PR TITLE
added missing parentheses for -tkn description

### DIFF
--- a/src/commanderProgram.js
+++ b/src/commanderProgram.js
@@ -48,7 +48,7 @@ program.option(
 );
 program.option(
   '-tkn, --token',
-  'get information on the tokens consumed (i.e., prompt, completion, & total tokens'
+  'get information on the tokens consumed (i.e., prompt, completion, & total tokens)'
 );
 
 // Exports the configured program

--- a/tests/unit/commanderProgram.test.js
+++ b/tests/unit/commanderProgram.test.js
@@ -49,7 +49,7 @@ describe('src/commanderProgram.js tests', () => {
       {
         flags: '-tkn, --token',
         description:
-          'get information on the tokens consumed (i.e., prompt, completion, & total tokens',
+          'get information on the tokens consumed (i.e., prompt, completion, & total tokens)',
       },
     ];
 


### PR DESCRIPTION
added the `)` to the end of the description for the -tkn / --token 