### PR TITLE
fix(default-prompt): use default prompt if user doesn't use -p or -pf

### DIFF
--- a/src/option_handlers/handleFilesOption.js
+++ b/src/option_handlers/handleFilesOption.js
@@ -34,6 +34,8 @@ export default async function handleFilesOption(files, options) {
     }
   } else if (options.prompt) {
     prompt = options.prompt || defaultPrompt;
+  } else {
+    prompt = defaultPrompt;
   }
 
   const model = options.model || toml?.preferences.MODEL || process.env.MODEL || 'gemini-1.5-flash';

--- a/src/option_handlers/handleNoFilesOption.js
+++ b/src/option_handlers/handleNoFilesOption.js
@@ -30,6 +30,8 @@ export default async function handleNoFilesOption(options) {
     }
   } else if (options.prompt) {
     prompt = options.prompt || defaultPrompt;
+  } else {
+    prompt = defaultPrompt;
   }
 
   const model = options.model || toml?.preferences.MODEL || process.env.MODEL || 'gemini-1.5-flash';


### PR DESCRIPTION
Noticed that the default prompt wasn't being used when the user didn't specify the `-p` or `-pf` options. This code fixes that.