### PR TITLE
chore: upgrade gemini-1.5-flash to gemini-2.0-flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,22 +86,22 @@ gr-ai -v
 To generate a `README.md` file for one or more source files:
 
 ```sh
-gr-ai -f example.js anotherFile.py -o README.md -m gemini-1.5-flash
+gr-ai -f example.js anotherFile.py -o README.md -m gemini-2.0-flash
 ```
 
 ### Generate the number of tokens used during the API call
 
 ```sh
-gr-ai -f example.js anotherFile.py -o README.md -m gemini-1.5-flash -tkn
+gr-ai -f example.js anotherFile.py -o README.md -m gemini-2.0-flash -tkn
 gr-ai -f example.js anotherFile.py -o README.md -m llama3-8b-8192 --token
 ```
 
 ## 4. Supported Models by Providers
 
-| Provider | Models           |
-| -------- | ---------------- |
-| `gemini` | gemini-1.5-flash |
-| `groq`   | llama3-8b-8192   |
+| Provider | Models                             |
+| -------- | ---------------------------------- |
+| `gemini` | gemini-2.0-flash, gemini-1.5-flash |
+| `groq`   | llama3-8b-8192                     |
 
 ## 5. Contributing
 

--- a/_examples/README.md
+++ b/_examples/README.md
@@ -44,7 +44,7 @@ Locates the config file if it does exist:
 ## Explain a file, output the result to a specific file, and set the temperature for the model
 
 ```sh
-gr-ai -m gemini-1.5-flash -f tests/unit/_gr.test.js -o explanation.md -t 0.1
+gr-ai -m gemini-2.0-flash -f tests/unit/_gr.test.js -o explanation.md -t 0.1
 ```
 
 ![explain-file](assets/images/explain-file.png)

--- a/env.sample
+++ b/env.sample
@@ -13,7 +13,7 @@
 [preferences]
   # Default model you prefer to use.
   # List of supported models: https://github.com/peterdanwan/gimme_readme#4-supported-models-by-providers
-  MODEL = "gemini-1.5-flash"
+  MODEL = "gemini-2.0-flash"
 
   # Default temperature you prefer to use (0-1)
   TEMPERATURE = 0.5

--- a/src/ai/ai.js
+++ b/src/ai/ai.js
@@ -16,7 +16,7 @@ import chalk from 'chalk';
 export default async function promptAI(prompt, model, temperature, outputFile, needToken) {
   if (model === null) {
     // Set the model to whatever is configured in their .env (default to gemini) and if that isn't set, set it to 'gemini'
-    model = 'gemini-1.5-flash';
+    model = 'gemini-2.0-flash';
   }
 
   if (typeof temperature === 'string') {

--- a/src/ai/models/geminiModels.js
+++ b/src/ai/models/geminiModels.js
@@ -1,4 +1,4 @@
 // src/ai/models/geminiModels.js
-const geminiModels = ['gemini-1.5-flash'];
+const geminiModels = ['gemini-2.0-flash', 'gemini-1.5-flash'];
 
 export default geminiModels;

--- a/src/commander/getUserOptions.js
+++ b/src/commander/getUserOptions.js
@@ -5,7 +5,7 @@ function getOptions(options) {
   const toml = getTOMLFileValues();
 
   return {
-    model: options.model || toml?.preferences.MODEL || process.env.MODEL || 'gemini-1.5-flash',
+    model: options.model || toml?.preferences.MODEL || process.env.MODEL || 'gemini-2.0-flash',
     outputFile: options.outputFile || toml?.OUTPUT_FILE || process.env.OUTPUT_FILE || null,
     temperature:
       options.temperature || toml?.preferences.TEMPERATURE || process.env.TEMPERATURE || 0.5,

--- a/tests/unit/ai/models/geminiModels.test.js
+++ b/tests/unit/ai/models/geminiModels.test.js
@@ -4,7 +4,7 @@ import geminiModels from '../../../../src/ai/models/geminiModels.js';
 
 describe('src/ai/models/geminiModels.js tests ', () => {
   test("Supported models in test match what's exported from the geminiModels.js module", () => {
-    const expectedModels = ['gemini-1.5-flash'];
+    const expectedModels = ['gemini-2.0-flash', 'gemini-1.5-flash'];
     expect(geminiModels).toEqual(expectedModels);
   });
 });


### PR DESCRIPTION
This pull request is in response to [Google AI Studio](https://aistudio.google.com/) _deprecating_ their `Gemini 1.5 models`.

> Hello Google AI Studio developer,
> We're writing to inform you that the following Gemini 1.5 models will be discontinued and will start returning errors on the dates indicated below:
> - `May 27, 2025`: Gemini 1.5 Pro 001, Gemini 1.5 Flash 001, and tuned versions of Gemini 1.5 Flash 001.
> - `September 24, 2025`: Gemini 1.5 Pro 002, Gemini 1.5 Flash 002, and Gemini 1.5 Flash-8B 001.

This pull request serves to update _most_ references to `gemini-1.5-flash` to `gemini-2.0-flash` in the documentation while still supporting the usage of `gemini-1.5-flash` model.

References to the `gemini-1.5-model` will be left in the following files _until_ `September 24, 2025`:
- [README.md](https://github.com/peterdanwan/gimme_readme/blob/main/README.md)
- [src/ai/models/geminiModels.js](https://github.com/peterdanwan/gimme_readme/blob/main/src/ai/models/geminiModels.js)
- [tests/unit/ai/models/geminiModels.test.js](https://github.com/peterdanwan/gimme_readme/blob/main/tests/unit/ai/models/geminiModels.test.js)